### PR TITLE
Add many GET endpoints for the exerciseAPI

### DIFF
--- a/src/main/java/com/fhcampuswien/MuscleMate/controller/ExerciseController.java
+++ b/src/main/java/com/fhcampuswien/MuscleMate/controller/ExerciseController.java
@@ -1,13 +1,12 @@
 package com.fhcampuswien.MuscleMate.controller;
 
-import com.fhcampuswien.MuscleMate.model.Exercise;
 import com.fhcampuswien.MuscleMate.service.ExerciseService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping(path = "api/exercise")
@@ -20,10 +19,50 @@ public class ExerciseController {
         this.exerciseService = exerciseService;
     }
 
-    @GetMapping
-    public List<Exercise> getExercise() {
-        return exerciseService.getExercise();
+    @GetMapping("/get-all-exercises")
+    public ResponseEntity<?> getAllExercises() {
+        return ResponseEntity.ok(exerciseService.getAllExercises());
+    }
 
+    @GetMapping("/get-all-body-parts")
+    public ResponseEntity<?> getAllBodyParts(){
+        return ResponseEntity.ok(exerciseService.getAllBodyParts());
+    }
+
+    @GetMapping("/get-all-muscles")
+    public ResponseEntity<?> getAllMuscles(){
+        return ResponseEntity.ok(exerciseService.getAllMuscles());
+    }
+
+    @GetMapping("/get-all-equipment")
+    public ResponseEntity<?> getAllEquipment(){
+        return ResponseEntity.ok(exerciseService.getAllEquipment());
+    }
+
+
+    @GetMapping("/muscle/{targetMuscle}")
+    public ResponseEntity<?> getExerciseByMuscle(@PathVariable("targetMuscle") String targetMuscle){
+        return ResponseEntity.ok(exerciseService.getExerciseByMuscle(targetMuscle));
+    }
+
+    @GetMapping("/bodyPart/{targetBodyPart}")
+    public ResponseEntity<?> getExerciseByBodyPart(@PathVariable("targetBodyPart") String targetBodyPart){
+        return ResponseEntity.ok(exerciseService.getExerciseByBodyPart(targetBodyPart));
+    }
+
+    @GetMapping("/exercise/{id}")
+    public ResponseEntity<?> getExerciseByID(@PathVariable("id") String id){
+        return ResponseEntity.ok(exerciseService.getExerciseByID(id));
+    }
+
+    @GetMapping("/name/{name}")
+    public ResponseEntity<?> getExerciseByName(@PathVariable("name") String name){
+        return ResponseEntity.ok(exerciseService.getExerciseByName(name));
+    }
+
+    @GetMapping("/equipment/{equipment}")
+    public ResponseEntity<?> getExerciseByEquipment(@PathVariable("equipment") String equipment){
+        return ResponseEntity.ok(exerciseService.getExerciseByEquipment(equipment));
     }
 
 }

--- a/src/main/java/com/fhcampuswien/MuscleMate/model/Exercise.java
+++ b/src/main/java/com/fhcampuswien/MuscleMate/model/Exercise.java
@@ -13,20 +13,21 @@ public class Exercise {
     private String type;
 
     private String muscle;
-
+    private String equipment;
     private String difficulty;
 
-    private Integer offset;
+    private String instructions;
 
 
     //Constructors
-    public Exercise(Integer id, String name, String type, String muscle, String difficulty, Integer offset) {
+    public Exercise(Integer id, String name, String type, String muscle, String difficulty, String equipment, String instructions ) {
         this.id = id;
         this.name = name;
         this.type = type;
         this.muscle = muscle;
+        this.equipment = equipment;
         this.difficulty = difficulty;
-        this.offset = offset;
+        this.instructions = instructions;
     }
 
     public Exercise() {
@@ -53,8 +54,12 @@ public class Exercise {
         return difficulty;
     }
 
-    public Integer getOffset() {
-        return offset;
+    public String getEquipment() {
+        return equipment;
+    }
+
+    public String getInstructions() {
+        return instructions;
     }
 
     //Setters
@@ -78,25 +83,26 @@ public class Exercise {
         this.difficulty = difficulty;
     }
 
-    public void setOffset(Integer offset) {
-        this.offset = offset;
+    public void setEquipment(String equipment) {
+        this.equipment = equipment;
     }
 
-    //equals
+    public void setInstructions(String instructions) {
+        this.instructions = instructions;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Exercise exercise = (Exercise) o;
-        return Objects.equals(id, exercise.id) && Objects.equals(name, exercise.name) && Objects.equals(type, exercise.type) && Objects.equals(muscle, exercise.muscle) && Objects.equals(difficulty, exercise.difficulty) && Objects.equals(offset, exercise.offset);
+        return Objects.equals(id, exercise.id) && Objects.equals(name, exercise.name) && Objects.equals(type, exercise.type) && Objects.equals(muscle, exercise.muscle) && Objects.equals(equipment, exercise.equipment) && Objects.equals(difficulty, exercise.difficulty) && Objects.equals(instructions, exercise.instructions);
     }
 
-    //hashCode
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, type, muscle, difficulty, offset);
+        return Objects.hash(id, name, type, muscle, equipment, difficulty, instructions);
     }
-
 
     @Override
     public String toString() {
@@ -105,8 +111,8 @@ public class Exercise {
                 ", name='" + name + '\'' +
                 ", type='" + type + '\'' +
                 ", muscle='" + muscle + '\'' +
+                ", equipment='" + equipment + '\'' +
                 ", difficulty='" + difficulty + '\'' +
-                ", offset=" + offset +
                 '}';
     }
 }

--- a/src/main/java/com/fhcampuswien/MuscleMate/service/ExerciseService.java
+++ b/src/main/java/com/fhcampuswien/MuscleMate/service/ExerciseService.java
@@ -1,26 +1,96 @@
 package com.fhcampuswien.MuscleMate.service;
 
-import com.fhcampuswien.MuscleMate.model.Exercise;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class ExerciseService {
 
-    //example of an exercise
-    public List<Exercise> getExercise() {
-        return List.of(
-                new Exercise(1, "Incline Hammer Curls", "biceps", "strength", "beginner", 0),
-                new Exercise(2, "Squats", "quadriceps", "strength", "intermediate", 0),
-                new Exercise(3, "Push-ups", "chest", "strength", "beginner", 0),
-                new Exercise(4, "Plank", "core", "endurance", "beginner", 0),
-                new Exercise(5, "Deadlifts", "hamstrings", "strength", "advanced", 0),
-                new Exercise(6, "Shoulder Press", "shoulders", "strength", "intermediate", 0),
-                new Exercise(7, "Lunges", "glutes", "strength", "beginner", 0),
-                new Exercise(8, "Crunches", "abs", "endurance", "beginner", 0),
-                new Exercise(9, "Bench Press", "chest", "strength", "intermediate", 0),
-                new Exercise(10, "Pull-ups", "back", "strength", "advanced", 0)
-        );
+//    @Value("${exercise.url}")
+    private static String URL = "https://exercisedb.p.rapidapi.com/exercises";
+
+//    @Value("${exercise.apiKey}")
+    private static String API_KEY = "4408a65727msha0928411da1b7e2p131262jsn0b98ffbdd584";
+
+//    @Value("${exercise.host}")
+    private static String HOST = "exercisedb.p.rapidapi.com";
+
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    //function for  making GET request for a specific endpoint.
+    private ResponseEntity<String> makeGETRequest(String endpoint) {
+        try {
+            // Set the headers
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-RapidAPI-Key", API_KEY);
+            headers.set("X-RapidAPI-Host", HOST);
+
+            // Make a GET request to the API
+            ResponseEntity<String> response = restTemplate.exchange(endpoint, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+            System.out.println("Output from the API: " + response.getBody());
+
+            return response;
+        } catch (Exception e) {
+            System.err.println("Something went wrong while getting value from the API");
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Exception while calling the API endpoint", e);
+        }
+    }
+
+
+    public Object getAllExercises() {
+        ResponseEntity<String> response = makeGETRequest(URL);
+        return response.getBody();
+    }
+
+
+    public Object getAllBodyParts() {
+        ResponseEntity<String> response = makeGETRequest(URL + "/bodyPartList");
+        return response.getBody();
+    }
+
+
+    public Object getAllMuscles() {
+        ResponseEntity<String> response = makeGETRequest(URL + "/targetList");
+        return response.getBody();
+    }
+
+
+    public Object getAllEquipment() {
+        ResponseEntity<String> response = makeGETRequest(URL + "/equipmentList");
+        return response.getBody();
+    }
+
+
+    public Object getExerciseByID(String id) {
+        ResponseEntity<String> response = makeGETRequest(URL + "/exercise/" + id);
+        return response.getBody();
+    }
+
+    public Object getExerciseByName(String name) {
+        ResponseEntity<String> response = makeGETRequest(URL + "/name/" + name);
+        return response.getBody();
+    }
+
+    public Object getExerciseByMuscle(String targetMuscle) {
+        ResponseEntity<String> response = makeGETRequest(URL + "/target/" + targetMuscle);
+        return response.getBody();
+    }
+
+    public Object getExerciseByBodyPart(String targetBodyPart) {
+        ResponseEntity<String> response = makeGETRequest(URL + "/bodyPart/" + targetBodyPart);
+        return response.getBody();
+    }
+
+
+    public Object getExerciseByEquipment(String equipment) {
+        ResponseEntity<String> response = makeGETRequest(URL + "/equipment/" + equipment);
+        return response.getBody();
     }
 }

--- a/src/main/java/com/fhcampuswien/MuscleMate/util/ExerciseConfigure.java
+++ b/src/main/java/com/fhcampuswien/MuscleMate/util/ExerciseConfigure.java
@@ -1,0 +1,15 @@
+package com.fhcampuswien.MuscleMate.util;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class ExerciseConfigure {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder){
+        return restTemplateBuilder.build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,8 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=
 
+exercise.url = "https://exercisedb.p.rapidapi.com/exercises/bodyPartList"
+
+exercise.apiKey = "4408a65727msha0928411da1b7e2p131262jsn0b98ffbdd584"
+
+exercise.host = "exercisedb.p.rapidapi.com"

--- a/src/main/resources/static/index.js
+++ b/src/main/resources/static/index.js
@@ -48,6 +48,6 @@ window.onload = function () {
 
     }
 
-    xhr.open("GET", "/api/exercise");
+    xhr.open("GET", "/api/exercise/get-all-exercises");
     xhr.send();
 }

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -14,8 +14,10 @@ body {
 }
 
 main{
+    margin-top: 25px;
     display: flex;
     flex-wrap: wrap;
+    gap: 10px;
 }
 
 


### PR DESCRIPTION
Update ExerciseController.java, ExerciseService.java, and ExerciseConfigure.java for connecting to ExerciseAPI.

Changes:

- Added different GET endpoints for accessing Exercice in many ways.
- Rewrote ExerciseService class. It now sets up a connection to the ExerciseAPI.
- Added static variables for URL, API_KEY, HOST.
- Used RestTemplate instance, which is autowired using the @Autowired annotation.
- Added a helper function makeGETRequest to handle making a GET request to specific paths of the API.
- Used RestTemplate.exchange() method to send the request and receive the response. The response is returned as a ResponseEntity<String>.
- Updated ExerciseConfigure.java for annotating the class and creating the RestTemplate bean using the factory method restTemplate(RestTemplateBuilder restTemplateBuilder).